### PR TITLE
Keep spiked ConnectionHandler, set pool in thread

### DIFF
--- a/lib/activerecord_autoreplica.rb
+++ b/lib/activerecord_autoreplica.rb
@@ -105,7 +105,7 @@ module AutoReplica
       self.current_read_pool = read_pool
       yield
     ensure
-      custom_handler.finish_read_context
+      current_read_pool.release_connection
       clear_current_read_pool
     end
   end
@@ -172,10 +172,6 @@ module AutoReplica
       end
     end
 
-    def release_read_pool_connection
-      AutoReplica.current_read_pool.release_connection
-    end
-
     # Close all the connections maintained by the read pool
     def disconnect_read_pool!
       AutoReplica.current_read_pool.disconnect!
@@ -193,11 +189,6 @@ module AutoReplica
     end
     def method_missing(method_name, *args, &blk)
       @original_handler.public_send(method_name, *args, &blk)
-    end
-
-    # When finishing, releases the borrowed connection back into the pool
-    def finish_read_context
-      release_read_pool_connection
     end
   end
 

--- a/spec/activerecord_autoreplica_spec.rb
+++ b/spec/activerecord_autoreplica_spec.rb
@@ -34,7 +34,9 @@ describe AutoReplica do
   end
 
   before :each do
+    allow(AutoReplica).to receive(:connection_set_up?).and_return(false)
     [@replica_connection_config, @master_connection_config].each do | config |
+      AutoReplica.clear_current_read_pool
       ActiveRecord::Base.establish_connection(config)
       ActiveRecord::Base.connection.execute 'DELETE FROM things' # sqlite has no TRUNCATE
     end
@@ -97,7 +99,7 @@ describe AutoReplica do
       found_on_master = TestThing.find(id)
       expect(found_on_master.description).to eq('A nice Thing in the master database')
     end
-    
+
     it 'does not contaminate other threads with the replica connection' do
       ActiveRecord::Base.establish_connection(@master_connection_config)
       TestThing.create! description: 'In master'
@@ -112,12 +114,12 @@ describe AutoReplica do
       expect(TestThing.first.description).to eq('In replica')
 
       ActiveRecord::Base.establish_connection(@master_connection_config)
-      
+
       Thread.abort_on_exception = true
       failures = 0
       successes = 0
       lock = Mutex.new
-      
+
       n_threads = 4
       n_iterations = 68
       readers_from_slave = (1..4).map do |n|
@@ -153,7 +155,7 @@ describe AutoReplica do
           end
         end
       end
-      
+
       readers_from_slave.map(&:join)
       readers_from_master.map(&:join)
 
@@ -171,7 +173,7 @@ describe AutoReplica do
       original_handler = double('ActiveRecord_ConnectionHandler')
       expect(original_handler).to receive(:do_that_thing) { :yes }
       pool_double = double('ConnectionPool')
-      subject = AutoReplica::ConnectionHandler.new(original_handler, pool_double)
+      subject = AutoReplica::ConnectionHandler.new(original_handler)
       expect(subject.do_that_thing).to eq(:yes)
     end
 
@@ -184,29 +186,30 @@ describe AutoReplica do
       expect(original_handler).to receive(:retrieve_connection).with(TestThing) { adapter_double }
       expect(pool_double).to receive(:connection) { connection_double }
 
-      subject = AutoReplica::ConnectionHandler.new(original_handler, pool_double)
+      subject = AutoReplica::ConnectionHandler.new(original_handler)
+      AutoReplica.current_read_pool = pool_double
       connection = subject.retrieve_connection(TestThing)
       expect(connection).to be_kind_of(AutoReplica::Adapter)
-      Thread.current[:autoreplica] = false
+      AutoReplica.clear_current_read_pool
     end
 
     it 'returns the original connection without the wrapper if the thread-local :autoreplica is not set' do
-      Thread.current[:autoreplica] = false
       original_handler = double('ActiveRecord_ConnectionHandler')
       pool_double = double('Read replica pool')
       expect(original_handler).to receive(:retrieve_connection).and_return(:original_connection)
-      subject = AutoReplica::ConnectionHandler.new(original_handler, pool_double)
+      subject = AutoReplica::ConnectionHandler.new(original_handler)
+      AutoReplica.clear_current_read_pool
       connection = subject.retrieve_connection(TestThing)
       expect(connection).to eq(:original_connection)
     end
-    
+
     it 'releases the the read pool connection when finishing' do
       original_handler = double('ActiveRecord_ConnectionHandler')
       pool_double = double('ConnectionPool')
-      subject = AutoReplica::ConnectionHandler.new(original_handler, pool_double)
-
+      subject = AutoReplica::ConnectionHandler.new(original_handler)
+      AutoReplica.current_read_pool = pool_double
       expect(pool_double).to receive(:release_connection)
-      subject.finish
+      subject.finish_read_context
     end
 
     it 'performs clear_all_connections! both on the contained handler and on the read pool' do
@@ -216,60 +219,8 @@ describe AutoReplica do
       expect(original_handler).to receive(:clear_all_connections!)
       expect(pool_double).to receive(:disconnect!)
 
-      subject = AutoReplica::ConnectionHandler.new(original_handler, pool_double)
-      subject.clear_all_connections!
-    end
-  end
-
-  describe AutoReplica::AdHocConnectionHandler do
-    it 'creates a read pool with the replica connection specification hash' do
-      original_handler = double('ActiveRecord_ConnectionHandler')
-      expect(ActiveRecord::ConnectionAdapters::ConnectionPool).to receive(:new).
-        with(instance_of(AutoReplica::ConnectionSpecification))
-
-      AutoReplica::AdHocConnectionHandler.new(original_handler, @replica_connection_config)
-    end
-
-    it 'proxies all methods' do
-      original_handler = double('ActiveRecord_ConnectionHandler')
-      expect(original_handler).to receive(:do_that_thing) { :yes }
-      subject = AutoReplica::AdHocConnectionHandler.new(original_handler, @replica_connection_config)
-      expect(subject.do_that_thing).to eq(:yes)
-    end
-
-    it 'enhances connection_for and returns an instance of the Adapter if the thread-local :autoreplica is set' do
-      Thread.current[:autoreplica] = true
-      original_handler = double('ActiveRecord_ConnectionHandler')
-      adapter_double = double('ActiveRecord_Adapter')
-      expect(original_handler).to receive(:retrieve_connection).with(TestThing) { adapter_double }
-
-      subject = AutoReplica::AdHocConnectionHandler.new(original_handler, @replica_connection_config)
-      connection = subject.retrieve_connection(TestThing)
-      expect(connection).to be_kind_of(AutoReplica::Adapter)
-      Thread.current[:autoreplica] = false
-    end
-
-    it 'disconnects the read pool when finishing' do
-      original_handler = double('ActiveRecord_ConnectionHandler')
-      pool_double = double('ConnectionPool')
-      expect(ActiveRecord::ConnectionAdapters::ConnectionPool).to receive(:new).
-        with(instance_of(AutoReplica::ConnectionSpecification)) { pool_double }
-      subject = AutoReplica::AdHocConnectionHandler.new(original_handler, @replica_connection_config)
-
-      expect(pool_double).to receive(:disconnect!)
-      subject.finish
-    end
-
-    it 'performs clear_all_connections! both on the contained handler and on the read pool' do
-      original_handler = double('ActiveRecord_ConnectionHandler')
-      pool_double = double('ConnectionPool')
-      expect(ActiveRecord::ConnectionAdapters::ConnectionPool).to receive(:new).
-        with(instance_of(AutoReplica::ConnectionSpecification)) { pool_double }
-
-      expect(original_handler).to receive(:clear_all_connections!)
-      expect(pool_double).to receive(:disconnect!)
-
-      subject = AutoReplica::AdHocConnectionHandler.new(original_handler, @replica_connection_config)
+      subject = AutoReplica::ConnectionHandler.new(original_handler)
+      AutoReplica.current_read_pool = pool_double
       subject.clear_all_connections!
     end
   end


### PR DESCRIPTION
The current functionality of `AutoReplica` is to set `ActiveRecord::Base.connection_handler` in the replica context, and reset it to the original when done. This, however, turns out to be risky.

`ActiveRecord::Base.connection_handler` is implemented using activesupport's `class_attribute`: the implementation of that is to define a method every time the variable is set, and, if the class variable is already existing, **remove the existing method and then define a new one**. This opens up to a race condition (as we observed in production): if the thread is killed in the middle of this operation (for example, by `rack_timeout`), `ActiveRecord::Base` can end up without a `connection_handler` method.

To avoid this, we propose to wrap `ConnectionHandler` once and keep it wrapped, and signal the switch to a replica pool via a thread-local variable.