### PR TITLE
Move connection setup to railtie

### DIFF
--- a/lib/activerecord_autoreplica/railtie.rb
+++ b/lib/activerecord_autoreplica/railtie.rb
@@ -1,0 +1,7 @@
+module AutoReplica
+  class Railtie < Rails::Railtie
+    initializer "activerecord_autoreplica.setup_connection" do
+      AutoReplica.setup_connection!
+    end
+  end
+end

--- a/spec/activerecord_autoreplica_spec.rb
+++ b/spec/activerecord_autoreplica_spec.rb
@@ -6,6 +6,7 @@ describe AutoReplica do
   before :all do
     test_seed_name = SecureRandom.hex(4)
     ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ('master_db_%s.sqlite3' % test_seed_name), pool: 10)
+    AutoReplica.setup_connection!
 
     # Setup the master and replica connections
     @master_connection_config = ActiveRecord::Base.connection_config.dup


### PR DESCRIPTION
There is still a potential for `ActiveRecord::Base.connection_handler` to be undefined, if `Rack::Timeout` kills the thread while the connection is being set. This should (hopefully) prevent that.